### PR TITLE
Removed dot in URL

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -15,7 +15,7 @@ title: Graph for Scala - Home
   Backed by the Scala core team, <em id="G4S">Graph for Scala</em> started in 2011 as an open
   source project in the EPFL Scala incubator space on
   <a href="https://www.assembla.com/spaces/scala-graph/wiki">Assembla</a>.
-  Meanwhile it is also hosted on <a href="https://github.com/scala-graph/scala-graph.">Github</a>.
+  Meanwhile it is also hosted on <a href="https://github.com/scala-graph/scala-graph">Github</a>.
 </p>
 <p>
   Want to take it for a spin? Grab the <a href="/download">latest release</a> to get started, then


### PR DESCRIPTION
The end `.` in the GitHub URL is taking it to a 404.
