### PR TITLE
Fix typo in initialization section

### DIFF
--- a/content/guides/core-initializing.html
+++ b/content/guides/core-initializing.html
@@ -454,7 +454,7 @@ var n, m = 0; val f = Graph.fill(100)( {n = m; m += 1; n~m} )
 		N is inferred to be <code>Int</code> because both the edge ends
 		and the single node are of type <code>Int</code>.
 	</li>
-	<li>Creates the very same directed graph as a). Operator <code>~</code>
+	<li>Creates the very same undirected graph as a). Operator <code>~</code>
 		is just a short-hand for invoking the factory <code>UnDiEdge</code>.
 	</li>
 	<li>Creates a directed graph of the type <code>Graph[AnyVal,DiEdge]</code>


### PR DESCRIPTION
The second line in the example is the same as the first line. It is just another way to write an undirected graph.